### PR TITLE
Advanced config reflects 'conf' changes

### DIFF
--- a/src/lib/wallet-util.js
+++ b/src/lib/wallet-util.js
@@ -170,7 +170,12 @@ class WalletUtil {
       }
 
       // Configure the minimal-slp-wallet library.
-      this.advancedConfig.restURL = server.restURL
+      if (server.restURL) {
+        this.advancedConfig.restURL = server.restURL
+      }
+      if (this.advancedConfig.interface !== server.interface) {
+        this.advancedConfig.interface = server.interface
+      }
       const bchWallet = new this.BchWallet(
         walletData.mnemonic,
         this.advancedConfig

--- a/test/unit/lib/wallet-util.unit.js
+++ b/test/unit/lib/wallet-util.unit.js
@@ -146,6 +146,36 @@ describe('#Wallet-Util', () => {
       await walletRemove.removeWallet(filepath)
     })
 
+    it('should read the config data', async () => {
+      // Force desired code paths
+      sandbox.stub(uut, 'getRestServer').returns({
+        interface: 'rest-api',
+        restURL: 'http://example.com'
+      })
+      // Mock minimal-slp-wallet
+      uut.BchWallet = class BchWallet {
+        async walletInfoPromise () {
+          return true
+        }
+
+        async initialize () {
+          return true
+        }
+      }
+      // Create a wallet
+      const filepath = walletRemove.getFilePath(walletName)
+      await walletCreate.createWallet(filepath)
+
+      const wallet = await uut.instanceWallet(walletName)
+
+      assert.isOk(wallet)
+      assert.equal(uut.advancedConfig.interface, 'rest-api')
+      assert.equal(uut.advancedConfig.restURL, 'http://example.com')
+
+      // Delete the wallet
+      await walletRemove.removeWallet(filepath)
+    })
+
     it('should catch, log, and throw errors', async () => {
       try {
         // Mock minimal-slp-wallet


### PR DESCRIPTION
After the setting in the constructor `advancedConfig.interface` is not updated from the `conf` and always stay `consumer-api`.